### PR TITLE
ci(dependabot): stop dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-approve-and-auto-merge.yml
+++ b/.github/workflows/dependabot-approve-and-auto-merge.yml
@@ -42,6 +42,9 @@ jobs:
     if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
+      - name: 'Do not auto-merge'
+        run: exit 0
+
       - name: 'Fetch Dependabot metadata'
         id: dependabot
         uses: dependabot/fetch-metadata@v2


### PR DESCRIPTION
Because we make changes infrequently, it is  easier to wait for all accumulated dependabot updates to run and to merge them each release cycle